### PR TITLE
Fix percent condition evaluation

### DIFF
--- a/featureflags_client/http/conditions.py
+++ b/featureflags_client/http/conditions.py
@@ -17,7 +17,7 @@ def except_false(func: Callable) -> Callable:
     def wrapper(ctx: Dict[str, Any]) -> Any:
         try:
             return func(ctx)
-        except TypeError:
+        except (TypeError, ValueError):
             return False
 
     return wrapper

--- a/featureflags_client/http/conditions.py
+++ b/featureflags_client/http/conditions.py
@@ -79,7 +79,7 @@ def percent(name: str, value: Any) -> Callable:
     @except_false
     def proc(ctx: Dict[str, Any]) -> bool:
         ctx_val = ctx.get(name, _UNDEFINED)
-        return ctx_val is not _UNDEFINED and hash(ctx_val) % 100 < value
+        return ctx_val is not _UNDEFINED and hash(ctx_val) % 100 < int(value)
 
     return proc
 

--- a/featureflags_client/tests/http/test_conditions.py
+++ b/featureflags_client/tests/http/test_conditions.py
@@ -98,6 +98,9 @@ def test_percent():
 
     assert check_op(_UNDEFINED, percent, 100) is False
 
+    assert check_op("foo", percent, '100') is True
+    assert check_op("foo", percent, 'not_number') is False
+
 
 def test_regexp():
     assert check_op("anything", regexp, ".") is True


### PR DESCRIPTION
Percentage condition doesn't work due to error

```python
TypeError: '<' not supported between instances of 'int' and 'str'
```