### PR TITLE
fix hash function to work on different workers the same

### DIFF
--- a/featureflags_client/http/conditions.py
+++ b/featureflags_client/http/conditions.py
@@ -3,6 +3,7 @@ import re
 from typing import Any, Callable, Dict, List, Optional, Set
 
 from featureflags_client.http.types import Check, Flag, Operator
+from featureflags_client.http.utils import hash_flag_value
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +80,11 @@ def percent(name: str, value: Any) -> Callable:
     @except_false
     def proc(ctx: Dict[str, Any]) -> bool:
         ctx_val = ctx.get(name, _UNDEFINED)
-        return ctx_val is not _UNDEFINED and hash(ctx_val) % 100 < int(value)
+        if ctx_val is _UNDEFINED:
+            return False
+
+        hash_ctx_val = hash_flag_value(name, ctx_val)
+        return hash_ctx_val % 100 < int(value)
 
     return proc
 

--- a/featureflags_client/http/utils.py
+++ b/featureflags_client/http/utils.py
@@ -1,4 +1,6 @@
+import hashlib
 import inspect
+import struct
 from enum import Enum, EnumMeta
 from typing import Any, Dict, Generator, Mapping, Type, Union
 
@@ -54,3 +56,9 @@ def intervals_gen(
         else:
             success = yield retry_interval
             retry_interval = min(retry_interval * 2, retry_interval_max)
+
+
+def hash_flag_value(name: str, value: Any) -> int:
+    hash_digest = hashlib.md5(f"{name}{value}".encode()).digest()  # noqa: S324
+    (hash_int,) = struct.unpack("<L", hash_digest[-4:])
+    return hash_int


### PR DESCRIPTION
Changelog:
- build-in `hash` function requires system setted SEED to work and gives different results depending on this SEED. replace with stable hash function which will give the same result on different workers